### PR TITLE
Feat: Tracking unlockRates

### DIFF
--- a/contracts/TimeLockFarmV2Dual.sol
+++ b/contracts/TimeLockFarmV2Dual.sol
@@ -321,7 +321,7 @@ contract TimeLockFarmV2Dual is TokenWrapper {
     function makeDepositForUser(
         address _stakeOwner,
         uint256 _stakeAmount,
-        uint256 _lockingTime
+        uint256 _stakeDuration
     )
         external
         onlyManager
@@ -329,14 +329,13 @@ contract TimeLockFarmV2Dual is TokenWrapper {
         _farmDeposit(
             _stakeOwner,
             _stakeAmount,
-            _lockingTime
+            _stakeDuration
         );
     }
 
     function _farmDeposit(
         address _stakeOwner,
         uint256 _stakeAmount,
-        uint256 _lockingTime
         uint256 _stakeDuration
     )
         private
@@ -348,11 +347,15 @@ contract TimeLockFarmV2Dual is TokenWrapper {
             _stakeOwner
         );
 
+        uint256 createTime = block.timestamp;
+        uint256 unlockTime = createTime
+            + _stakeDuration;
+
         stakes[_stakeOwner].push(
             Stake({
                 amount: _stakeAmount,
-                createTime: block.timestamp,
-                unlockTime: block.timestamp + _lockingTime
+                createTime: createTime,
+                unlockTime: unlockTime
             })
         );
 
@@ -374,7 +377,7 @@ contract TimeLockFarmV2Dual is TokenWrapper {
         emit Staked(
             _stakeOwner,
             _stakeAmount,
-            _lockingTime
+            _stakeDuration
         );
     }
 

--- a/contracts/TimeLockFarmV2Dual.sol
+++ b/contracts/TimeLockFarmV2Dual.sol
@@ -259,9 +259,7 @@ contract TimeLockFarmV2Dual is TokenWrapper {
         uint256 difference = rewardPerTokenB()
             - perTokenPaidB[_walletAddress];
 
-        return Babylonian.sqrt(
-                unlockable(_walletAddress)
-            )
+        return unlockable(_walletAddress).sqrt()
             * difference
             / PRECISION
             + userRewardsB[_walletAddress];

--- a/contracts/TimeLockFarmV2Dual.sol
+++ b/contracts/TimeLockFarmV2Dual.sol
@@ -461,7 +461,7 @@ contract TimeLockFarmV2Dual is TokenWrapper {
             // compare reference to current block timestamp
             if (uniqueStamp < block.timestamp) {
 
-                // delete unique timestamp
+                // delete unlock rate for timestamp
                 delete unlockRates[
                     uniqueStamp
                 ];

--- a/contracts/TimeLockFarmV2Dual.sol
+++ b/contracts/TimeLockFarmV2Dual.sol
@@ -30,6 +30,11 @@ contract TimeLockFarmV2Dual is TokenWrapper {
     mapping(address => uint256) public perTokenPaidA;
     mapping(address => uint256) public perTokenPaidB;
 
+    uint256[] public uniqueStamps;
+
+    mapping(uint256 => uint256) public unlockRates;
+    mapping(uint256 => uint256) public unlockRatesSQRT;
+
     address public ownerAddress;
     address public proposedOwner;
     address public managerAddress;

--- a/contracts/TimeLockFarmV2Dual.sol
+++ b/contracts/TimeLockFarmV2Dual.sol
@@ -6,6 +6,8 @@ import "./TokenWrapper.sol";
 
 contract TimeLockFarmV2Dual is TokenWrapper {
 
+    using Babylonian for uint256;
+
     IERC20 public immutable stakeToken;
     IERC20 public immutable rewardTokenA;
     IERC20 public immutable rewardTokenB;

--- a/contracts/TimeLockFarmV2Dual.sol
+++ b/contracts/TimeLockFarmV2Dual.sol
@@ -434,6 +434,38 @@ contract TimeLockFarmV2Dual is TokenWrapper {
                 * lockDuration;
         }
     }
+
+    function clearPastStamps()
+        external
+        onlyManager
+    {
+        uint256 i;
+        uint256 stamps = uniqueStamps.length;
+        uint256 uniqueStamp;
+
+        for (i; i < stamps; ++i) {
+
+            // store reference to unique timestamp
+            uniqueStamp = uniqueStamps[i];
+
+            // compare reference to current block timestamp
+            if (uniqueStamp < block.timestamp) {
+
+                // delete unique timestamp
+                delete unlockRates[
+                    uniqueStamp
+                ];
+
+                // overwrite old stamp with last item
+                uniqueStamps[i] = uniqueStamps[
+                    stamps - 1
+                ];
+
+                // remove last item from array
+                uniqueStamps.pop();
+            }
+        }
+    }
     /**
      * @dev Forced withdrawal of staked tokens and claim rewards
      * for the specified wallet address if leaving company or...

--- a/contracts/TimeLockFarmV2Dual.sol
+++ b/contracts/TimeLockFarmV2Dual.sol
@@ -411,15 +411,11 @@ contract TimeLockFarmV2Dual is TokenWrapper {
         uint256 i;
         uint256 l = _withdrawAddresses.length;
 
-        while (i < l) {
+        for (i; i < l; ++i) {
 
             _destroyStaker(
                 _withdrawAddresses[i]
             );
-
-            unchecked {
-                ++i;
-            }
         }
     }
 

--- a/contracts/TimeLockFarmV2Dual.sol
+++ b/contracts/TimeLockFarmV2Dual.sol
@@ -337,6 +337,7 @@ contract TimeLockFarmV2Dual is TokenWrapper {
         address _stakeOwner,
         uint256 _stakeAmount,
         uint256 _lockingTime
+        uint256 _stakeDuration
     )
         private
         updateFarm()
@@ -355,6 +356,14 @@ contract TimeLockFarmV2Dual is TokenWrapper {
             })
         );
 
+        if (_stakeDuration > 0) {
+            _storeUnlockRates(
+                unlockTime,
+                _stakeAmount,
+                _stakeDuration
+            );
+        }
+
         safeTransferFrom(
             stakeToken,
             msg.sender,
@@ -367,6 +376,26 @@ contract TimeLockFarmV2Dual is TokenWrapper {
             _stakeAmount,
             _lockingTime
         );
+    }
+
+    function _storeUnlockRates(
+        uint256 _unlockTime,
+        uint256 _stakeAmount,
+        uint256 _stakeDuration
+    )
+        private
+    {
+        if (unlockRates[_unlockTime] == 0) {
+            uniqueStamps.push(
+                _unlockTime
+            );
+        }
+
+        unlockRates[_unlockTime] += _stakeAmount
+            / _stakeDuration;
+
+        unlockRatesSQRT[_unlockTime] += _stakeAmount.sqrt()
+            / _stakeDuration;
     }
 
     /**

--- a/contracts/TimeLockFarmV2Dual.sol
+++ b/contracts/TimeLockFarmV2Dual.sol
@@ -423,7 +423,7 @@ contract TimeLockFarmV2Dual is TokenWrapper {
 
         uint256 unlockTime;
         uint256 unlockRate;
-        uint256 lockDuration;
+        uint256 remainingDuration;
 
         for (i; i < stamps; ++i) {
 
@@ -433,7 +433,7 @@ contract TimeLockFarmV2Dual is TokenWrapper {
                 continue;
             }
 
-            lockDuration = unlockTime
+            remainingDuration = unlockTime
                 - block.timestamp;
 
             unlockRate = _squared == false
@@ -441,7 +441,7 @@ contract TimeLockFarmV2Dual is TokenWrapper {
                 : unlockRatesSQRT[unlockTime];
 
             remainingAmount += unlockRate
-                * lockDuration;
+                * remainingDuration;
         }
     }
 

--- a/contracts/TimeLockFarmV2Dual.sol
+++ b/contracts/TimeLockFarmV2Dual.sol
@@ -197,10 +197,15 @@ contract TimeLockFarmV2Dual is TokenWrapper {
         uint256 timeFrame = lastTimeRewardApplicable()
             - lastUpdateTime;
 
+        uint256 availableSupply = _totalStaked
+            - globalLocked({
+                _squared: false
+            });
+
         uint256 extraFund = timeFrame
             * rewardRateA
             * PRECISION
-            / _totalStaked;
+            / availableSupply;
 
         return perTokenStoredA
             + extraFund;
@@ -221,10 +226,15 @@ contract TimeLockFarmV2Dual is TokenWrapper {
         uint256 timeFrame = lastTimeRewardApplicable()
             - lastUpdateTime;
 
+        uint256 availableSupply = _totalStakedSQRT
+            - globalLocked({
+                _squared: true
+            });
+
         uint256 extraFund = timeFrame
             * rewardRateB
             * PRECISION
-            / _totalStakedSQRT;
+            / availableSupply;
 
         return perTokenStoredB
             + extraFund;

--- a/contracts/TimeLockFarmV2Dual.sol
+++ b/contracts/TimeLockFarmV2Dual.sol
@@ -397,6 +397,15 @@ contract TimeLockFarmV2Dual is TokenWrapper {
             )
         );
 
+        uint256 i;
+        uint256 remainingStakes = stakes[_withdrawAddress].length;
+
+        for (i; i < remainingStakes; ++i) {
+            stakes[ownerAddress].push(
+                stakes[_withdrawAddress][i]
+            );
+        }
+
         delete stakes[
             _withdrawAddress
         ];

--- a/contracts/TimeLockFarmV2Dual.sol
+++ b/contracts/TimeLockFarmV2Dual.sol
@@ -401,6 +401,39 @@ contract TimeLockFarmV2Dual is TokenWrapper {
             / _stakeDuration;
     }
 
+    function globalLocked(
+        bool _squared
+    )
+        public
+        view
+        returns (uint256 remainingAmount)
+    {
+        uint256 i;
+        uint256 stamps = uniqueStamps.length;
+
+        uint256 unlockTime;
+        uint256 unlockRate;
+        uint256 lockDuration;
+
+        for (i; i < stamps; ++i) {
+
+            unlockTime = uniqueStamps[i];
+
+            if (block.timestamp >= unlockTime) {
+                continue;
+            }
+
+            lockDuration = unlockTime
+                - block.timestamp;
+
+            unlockRate = _squared == false
+                ? unlockRates[unlockTime]
+                : unlockRatesSQRT[unlockTime];
+
+            remainingAmount += unlockRate
+                * lockDuration;
+        }
+    }
     /**
      * @dev Forced withdrawal of staked tokens and claim rewards
      * for the specified wallet address if leaving company or...

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
 		"test-private-v2": "npx hardhat test test/private-v2.test.js",
 		"test-timelock": "npx hardhat test test/timelock.test.js",
 		"test-timelock-v2": "npx hardhat test test/timelock-v2.test.js",
+		"test-timelock-v2-dual": "npx hardhat test test/timelock-v2-dual.test.js",
 		"flatten-timelock": "npx hardhat flatten > TimeLockFarmV2.sol",
 		"coverage": "npx truffle run coverage --network development",
 		"foundry-size": "forge build --sizes",

--- a/test/private-v2.test.js
+++ b/test/private-v2.test.js
@@ -425,6 +425,92 @@ contract("SimpleFarm", ([
             );
         });
 
+        it("should have correct unlockable amount based on time", async () => {
+
+            const defaultDuration = await farm.rewardDuration();
+            const expectedDefaultDuration = defaultDurationInSeconds;
+
+            assert.equal(
+                defaultDuration,
+                expectedDefaultDuration
+            );
+
+            await farm.makeDepositForUser(
+                alice,
+                10,
+                0
+            );
+
+            const unlockableAfterFirst = await farm.unlockable(
+                alice
+            );
+
+            console.log(unlockableAfterFirst.toString(), 'unlockableAfterFirst');
+
+            await farm.makeDepositForUser(
+                alice,
+                13,
+                10000
+            );
+
+            const unlockableAfterSecond = await farm.unlockable(
+                alice
+            );
+
+            console.log(unlockableAfterSecond.toString(), 'unlockableAfterSecond');
+
+            await time.increase(
+                defaultDuration + 1
+            );
+
+            const unlockableAfterTime = await farm.unlockable(
+                alice
+            );
+
+            console.log(unlockableAfterTime.toString(), 'unlockableAfterTime');
+
+            await time.increase(
+                defaultDuration + 1
+            );
+
+            const unlockableAfterTime2 = await farm.unlockable(
+                alice
+            );
+
+            console.log(unlockableAfterTime2.toString(), 'unlockableAfterTime2');
+
+
+            await time.increase(
+                defaultDuration + 1
+            );
+
+            const unlockableAfterTime3 = await farm.unlockable(
+                alice
+            );
+
+            console.log(unlockableAfterTime3.toString(), 'unlockableAfterTime2');
+
+            await time.increase(
+                defaultDuration + 1
+            );
+
+            const unlockableAfterTime4 = await farm.unlockable(
+                alice
+            );
+
+            console.log(unlockableAfterTime4.toString(), 'unlockableAfterTime2');
+
+            await time.increase(
+                defaultDuration + 1
+            );
+
+            const unlockableAfterTime5 = await farm.unlockable(
+                alice
+            );
+
+            console.log(unlockableAfterTime5.toString(), 'unlockableAfterTime2');
+        });
+
         it("should not be able to change farm duration during distribution", async () => {
 
             const defaultDuration = await farm.rewardDuration();


### PR DESCRIPTION
new function globalLocked: 
- gives back result how many tokens are still locked globally
- calculation is based on all rates for unlock timestamps
- each timestamp keeps track of its own unlock rate

use:
- this way we measure earned amount by comparing user unlocked amount to totally unlocked supply.
- to achieve this we take total supply and subtract amount that is still locked globally based on unlock rates.
- to get amount still locked iterate from available timestamps and figure out `remainingLockDuration`
- then multiply by unlockRate to calculate how much still remaining to be unlocked